### PR TITLE
feature: add lifecycle beforeReload

### DIFF
--- a/agent.js
+++ b/agent.js
@@ -42,6 +42,20 @@ module.exports = agent => {
     }
   });
 
+  // add simple lifecycle beforeReload 
+  const scopeList = [];
+  agent.beforeReload = async function (scope) {
+    scopeList.push(scope);
+  }
+
+  // run lifecycle beforeReload function
+  async function runBeforeReloadFunc()
+  {
+    for (const scope of scopeList) {
+        await scope();
+    }
+  }
+
   /**
    * reload app worker:
    *   [AgentWorker] - on file change
@@ -53,7 +67,7 @@ module.exports = agent => {
    *
    * @param {Object} info - changed fileInfo
    */
-  function reloadWorker(info) {
+  async function reloadWorker(info) {
     if (!config.reloadOnDebug) {
       return;
     }
@@ -66,6 +80,9 @@ module.exports = agent => {
     if (config.reloadPattern && multimatch(info.path, config.reloadPattern).length === 0) {
       return;
     }
+
+    // dev lifecycle add BeforeReload events
+    await runBeforeReloadFunc();
 
     logger.warn(`[agent:development] reload worker because ${info.path} ${info.event}`);
 


### PR DESCRIPTION
可能是首次使用egg，所以可能这个不是最好的解决方法，希望能够评定 <br />
原因：<br />
假设我需要在beforeStart中执行某项数据操作并在beforeClose中回收。<br />
但在开发阶段触发文件改变时，并无法通知到我。
理由如下：<br />
* worker交替时，会继续触发beforeStart，而未触发beforeClose
* 即使添加beforeClose触发，由于保证无缝切换机制，所以新worker完成触发beforeStart，但旧worker还未close
* beforeReload在本地开发阶段是相对必要的存在


<br />希望先讨论评定后，后续再抽时间过Checklist<br />

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message follows commit guidelines

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
